### PR TITLE
refactor: Preserve stack trace in error handling

### DIFF
--- a/nodes/Pterodactyl/transport/PterodactylApiRequest.ts
+++ b/nodes/Pterodactyl/transport/PterodactylApiRequest.ts
@@ -94,6 +94,7 @@ export async function pterodactylApiRequest(
 			// Create clean error without circular references
 			const cleanError = new Error(error.message || 'Unknown error occurred');
 			cleanError.name = error.name || 'Error';
+			cleanError.stack = error.stack; // Preserve stack trace for debugging
 			if (error.statusCode) {
 				(cleanError as any).statusCode = error.statusCode;
 			}


### PR DESCRIPTION
## Summary
Addresses medium severity code review suggestion from PR #4.

## Changes
- **Preserve stack trace**: Add `cleanError.stack = error.stack` to maintain debugging context
- **Zero risk**: Single line addition, no behavioral changes
- **Better debugging**: Developers can now trace errors back to their source

## Context
While fixing the circular reference bug in PR #4, we created clean error objects but didn't preserve the stack trace. This PR adds that missing piece for better debugging experience.

## Testing
- ✅ Builds successfully
- ✅ No functional changes, only adds debugging information
- ✅ Compatible with existing error handling

## Related
- Addresses code review feedback from PR #4
- Part of iterative improvements for error handling

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)