### PR TITLE
fix: update GitHub Actions workflow to use modern release action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -32,11 +35,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
+          generate_release_notes: true


### PR DESCRIPTION
## Problem
The v1.0.0 release workflow failed with error: `Resource not accessible by integration`

The issue was caused by:
- Using deprecated `actions/create-release@v1` action
- Missing required `permissions` configuration for GITHUB_TOKEN

## Solution
- ✅ Replace with modern `softprops/action-gh-release@v2`
- ✅ Add required permissions (`contents: write`, `id-token: write`)
- ✅ Enable automatic release notes generation

## Testing
Need to re-trigger the v1.0.0 tag after merge to complete the release process.

Fixes the failure from: https://github.com/goevexx/pterodactyl-api-node/actions/runs/18205350739/job/51834286498