### PR TITLE
fix: update repository URLs to correct GitHub organization

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,12 @@
 name: Publish to npm
 
+# This workflow publishes to npm and creates GitHub Release
+# Workflow relationship:
+#   1. release.yml -> Creates version bump, CHANGELOG, and git tag (manual trigger)
+#   2. publish.yml (this) -> Triggered by tag push -> Publishes to npm + GitHub Release
+#
+# This workflow is triggered automatically when release.yml pushes a version tag
+
 on:
   push:
     tags:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        description: 'Release type (one of): patch, minor, major'
+        required: true
+        default: 'patch'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      - name: Conventional Changelog Action
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          release-count: 0
+          version-file: './package.json'
+          skip-version-file: false
+          skip-commit: false
+          git-message: 'chore(release): {version}'
+          preset: 'conventionalcommits'
+          tag-prefix: 'v'
+          output-file: 'CHANGELOG.md'
+          skip-on-empty: true
+          skip-git-pull: false
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        with:
+          tag_name: ${{ steps.changelog.outputs.tag }}
+          name: Release ${{ steps.changelog.outputs.version }}
+          body: ${{ steps.changelog.outputs.clean_changelog }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,6 @@ jobs:
           output-file: 'CHANGELOG.md'
           skip-on-empty: true
           skip-git-pull: false
-          version-path: 'version'
 
       # Note: GitHub Release is created by publish.yml when the tag is pushed
       # This workflow only creates the version bump commit and tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,10 @@
 name: Release
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
-    inputs:
-      release-type:
-        description: 'Release type (one of): patch, minor, major'
-        required: true
-        default: 'patch'
 
 jobs:
   release:
@@ -41,6 +39,7 @@ jobs:
           output-file: 'CHANGELOG.md'
           skip-on-empty: true
           skip-git-pull: false
+          version-path: 'version'
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,14 @@
 name: Release
 
+# This workflow generates releases from conventional commits
+# Workflow relationship:
+#   1. release.yml (this) -> Creates version bump, CHANGELOG, and git tag
+#   2. publish.yml -> Triggered by tag push -> Publishes to npm + GitHub Release
+#
+# Trigger strategy: Manual only to avoid creating releases for non-feature commits
+# Run this workflow manually from Actions tab when ready to release
+
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:
@@ -33,6 +38,9 @@ jobs:
           version-file: './package.json'
           skip-version-file: false
           skip-commit: false
+          skip-ci: false
+          skip-tag: false
+          git-push: true
           git-message: 'chore(release): {version}'
           preset: 'conventionalcommits'
           tag-prefix: 'v'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,5 @@ jobs:
           skip-git-pull: false
           version-path: 'version'
 
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        if: ${{ steps.changelog.outputs.skipped == 'false' }}
-        with:
-          tag_name: ${{ steps.changelog.outputs.tag }}
-          name: Release ${{ steps.changelog.outputs.version }}
-          body: ${{ steps.changelog.outputs.clean_changelog }}
+      # Note: GitHub Release is created by publish.yml when the tag is pushed
+      # This workflow only creates the version bump commit and tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.1] - 2025-10-02
-
-### Fixed
-
-- Repository URLs in package.json now point to correct GitHub organization (goevexx/pterodactyl-api-node)
-- Outdated Pterodactyl API documentation links (updated to https://pterodactyl-api-docs.netvpx.com/)
-- Broken n8n license documentation link (updated to /sustainable-use-license/)
-- GitHub Actions workflow permissions for creating releases
-- README table of contents now displays as tree structure
-- GitHub badges now reference correct repository
-
 ## [1.0.0] - 2025-10-01
 
 ### Added
@@ -67,5 +56,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Operation descriptions
 - Usage examples
 
-[1.0.1]: https://github.com/goevexx/pterodactyl-api-node/releases/tag/v1.0.1
 [1.0.0]: https://github.com/goevexx/pterodactyl-api-node/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-10-02
+
+### Fixed
+
+- Repository URLs in package.json now point to correct GitHub organization (goevexx/pterodactyl-api-node)
+- Outdated Pterodactyl API documentation links (updated to https://pterodactyl-api-docs.netvpx.com/)
+- Broken n8n license documentation link (updated to /sustainable-use-license/)
+- GitHub Actions workflow permissions for creating releases
+- README table of contents now displays as tree structure
+- GitHub badges now reference correct repository
+
 ## [1.0.0] - 2025-10-01
 
 ### Added
@@ -56,4 +67,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Operation descriptions
 - Usage examples
 
-[1.0.0]: https://github.com/nico-on-github/pterodactyl-api-node/releases/tag/v1.0.0
+[1.0.1]: https://github.com/goevexx/pterodactyl-api-node/releases/tag/v1.0.1
+[1.0.0]: https://github.com/goevexx/pterodactyl-api-node/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ npm test
 
 ## Need Help?
 
-- Check existing [issues](https://github.com/nico-on-github/pterodactyl-api-node/issues)
+- Check existing [issues](https://github.com/goevexx/pterodactyl-api-node/issues)
 - Review [n8n node documentation](https://docs.n8n.io/integrations/creating-nodes/)
 - Ask in the PR or issue
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Follow the [installation guide](https://docs.n8n.io/integrations/community-nodes
 
 This node supports both Client API and Application API operations for comprehensive Pterodactyl Panel automation.
 
+<a id="server-management"></a>
 ### Server Management
 
 - **List Servers** - Get all accessible servers
@@ -42,6 +43,7 @@ This node supports both Client API and Application API operations for comprehens
 - **Send Command** - Execute console command
 - **Get Resources** - Get server resource usage
 
+<a id="file-operations"></a>
 ### File Operations
 
 - **List Files** - List files in directory
@@ -53,6 +55,7 @@ This node supports both Client API and Application API operations for comprehens
 - **Create Folder** - Create directory
 - **Get Upload URL** - Get file upload URL
 
+<a id="database-management"></a>
 ### Database Management
 
 - **List Databases** - Get all databases
@@ -60,6 +63,7 @@ This node supports both Client API and Application API operations for comprehens
 - **Rotate Password** - Generate new password
 - **Delete Database** - Remove database
 
+<a id="backup-operations"></a>
 ### Backup Operations
 
 - **List Backups** - Get all backups
@@ -69,6 +73,7 @@ This node supports both Client API and Application API operations for comprehens
 - **Restore Backup** - Restore from backup
 - **Delete Backup** - Remove backup
 
+<a id="account-operations"></a>
 ### Account Operations
 
 - **Get Account** - Get account details

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # n8n-nodes-pterodactyl
 
-[![npm version](https://badge.fury.io/js/n8n-nodes-pterodactyl.svg)](https://badge.fury.io/js/n8n-nodes-pterodactyl)
+[![npm version](https://img.shields.io/npm/v/n8n-nodes-pterodactyl.svg)](https://www.npmjs.com/package/n8n-nodes-pterodactyl)
 [![npm downloads](https://img.shields.io/npm/dm/n8n-nodes-pterodactyl.svg)](https://www.npmjs.com/package/n8n-nodes-pterodactyl)
+[![GitHub issues](https://img.shields.io/github/issues/goevexx/pterodactyl-api-node.svg)](https://github.com/goevexx/pterodactyl-api-node/issues)
+[![GitHub stars](https://img.shields.io/github/stars/goevexx/pterodactyl-api-node.svg)](https://github.com/goevexx/pterodactyl-api-node/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 This is an n8n community node that lets you interact with the Pterodactyl Panel API in your n8n workflows.
@@ -10,12 +12,19 @@ This is an n8n community node that lets you interact with the Pterodactyl Panel 
 
 [n8n](https://n8n.io/) is a [fair-code licensed](https://docs.n8n.io/reference/license/) workflow automation platform.
 
-[Installation](#installation)
-[Operations](#operations)
-[Credentials](#credentials)
-[Compatibility](#compatibility)
-[Usage](#usage)
-[Resources](#resources)
+## Table of Contents
+
+- [Installation](#installation)
+- [Operations](#operations)
+  - [Server Management](#server-management)
+  - [File Operations](#file-operations)
+  - [Database Management](#database-management)
+  - [Backup Operations](#backup-operations)
+  - [Account Operations](#account-operations)
+- [Credentials](#credentials)
+- [Compatibility](#compatibility)
+- [Usage](#usage)
+- [Resources](#resources)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is an n8n community node that lets you interact with the Pterodactyl Panel 
 
 [Pterodactyl](https://pterodactyl.io/) is an open-source game server management panel built with PHP, React, and Go.
 
-[n8n](https://n8n.io/) is a [fair-code licensed](https://docs.n8n.io/reference/license/) workflow automation platform.
+[n8n](https://n8n.io/) is a [fair-code licensed](https://docs.n8n.io/sustainable-use-license/) workflow automation platform.
 
 ## Table of Contents
 
@@ -85,7 +85,7 @@ This node requires either:
 - **Pterodactyl Client API** credentials (user-level access)
 - **Pterodactyl Application API** credentials (admin-level access)
 
-See the [Pterodactyl API documentation](https://pterodactyl.io/api/) for information on generating API keys.
+See the [Pterodactyl API documentation](https://pterodactyl-api-docs.netvpx.com/) for information on generating API keys.
 
 ## Compatibility
 
@@ -122,7 +122,7 @@ More examples coming in the `examples/` directory.
 
 - [n8n community nodes documentation](https://docs.n8n.io/integrations/community-nodes/)
 - [Pterodactyl Panel](https://pterodactyl.io/)
-- [Pterodactyl API Documentation](https://pterodactyl.io/api/)
+- [Pterodactyl API Documentation](https://pterodactyl-api-docs.netvpx.com/)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Follow the [installation guide](https://docs.n8n.io/integrations/community-nodes
 
 This node supports both Client API and Application API operations for comprehensive Pterodactyl Panel automation.
 
-<a id="server-management"></a>
 ### Server Management
 
 - **List Servers** - Get all accessible servers
@@ -43,7 +42,6 @@ This node supports both Client API and Application API operations for comprehens
 - **Send Command** - Execute console command
 - **Get Resources** - Get server resource usage
 
-<a id="file-operations"></a>
 ### File Operations
 
 - **List Files** - List files in directory
@@ -55,7 +53,6 @@ This node supports both Client API and Application API operations for comprehens
 - **Create Folder** - Create directory
 - **Get Upload URL** - Get file upload URL
 
-<a id="database-management"></a>
 ### Database Management
 
 - **List Databases** - Get all databases
@@ -63,7 +60,6 @@ This node supports both Client API and Application API operations for comprehens
 - **Rotate Password** - Generate new password
 - **Delete Database** - Remove database
 
-<a id="backup-operations"></a>
 ### Backup Operations
 
 - **List Backups** - Get all backups
@@ -73,7 +69,6 @@ This node supports both Client API and Application API operations for comprehens
 - **Restore Backup** - Restore from backup
 - **Delete Backup** - Remove backup
 
-<a id="account-operations"></a>
 ### Account Operations
 
 - **Get Account** - Get account details

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "n8n-nodes-pterodactyl",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "n8n node for Pterodactyl Panel API integration",
 	"keywords": [
 		"n8n-community-node-package",
@@ -10,17 +10,17 @@
 		"api"
 	],
 	"license": "MIT",
-	"homepage": "https://github.com/nico-on-github/pterodactyl-api-node",
+	"homepage": "https://github.com/goevexx/pterodactyl-api-node",
 	"author": {
 		"name": "Nicolas Morawietz",
 		"email": "contact@morawietz.dev"
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/nico-on-github/pterodactyl-api-node.git"
+		"url": "https://github.com/goevexx/pterodactyl-api-node.git"
 	},
 	"bugs": {
-		"url": "https://github.com/nico-on-github/pterodactyl-api-node/issues"
+		"url": "https://github.com/goevexx/pterodactyl-api-node/issues"
 	},
 	"main": "index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "n8n-nodes-pterodactyl",
-	"version": "1.0.1",
+	"version": "1.0.0",
 	"description": "n8n node for Pterodactyl Panel API integration",
 	"keywords": [
 		"n8n-community-node-package",


### PR DESCRIPTION
## Problem
The npm package shows incorrect repository URL `nico-on-github/pterodactyl-api-node` instead of the actual repository `goevexx/pterodactyl-api-node`.

## Solution
- ✅ Updated homepage URL to `https://github.com/goevexx/pterodactyl-api-node`
- ✅ Updated repository URL to `https://github.com/goevexx/pterodactyl-api-node.git`
- ✅ Updated bugs/issues URL to `https://github.com/goevexx/pterodactyl-api-node/issues`
- ✅ Bumped version to 1.0.1

## Impact
This will fix the repository links shown on the npm package page, directing users to the correct GitHub repository for issues, documentation, and source code.