### PR TITLE
chore(release): v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1](https://github.com/goevexx/pterodactyl-api-node/compare/v1.0.0...v1.0.1) (2025-10-02)
+
+
+### Bug Fixes
+
+* update repository URLs to correct GitHub organization ([#12](https://github.com/goevexx/pterodactyl-api-node/issues/12)) ([69c58a1](https://github.com/goevexx/pterodactyl-api-node/commit/69c58a19639f2bce5a17b9e3050d421dfb9b2b6f))
+
+
+
 ## [1.0.0] - 2025-10-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "n8n-nodes-pterodactyl",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "n8n node for Pterodactyl Panel API integration",
 	"keywords": [
 		"n8n-community-node-package",


### PR DESCRIPTION
## Release v1.0.1

This PR completes the v1.0.1 release by bumping the package version and updating CHANGELOG.

### Changes
- Bump package.json version to 1.0.1  
- Add CHANGELOG entry for v1.0.1

### Context
The automated release workflow successfully created the v1.0.1 tag but couldn't push the version bump commit due to branch protection. This PR manually applies those changes.

### What happens after merge:
1. Merge this PR
2. Delete and recreate v1.0.1 tag (to point to new commit)
3. Tag push triggers npm publish automatically