### PR TITLE
chore(release): v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2](https://github.com/goevexx/pterodactyl-api-node/compare/v1.0.1...v1.0.2) (2025-10-03)
+
+
+### Bug Fixes
+
+* remove setTimeout to pass n8n verification ([#14](https://github.com/goevexx/pterodactyl-api-node/issues/14)) ([#15](https://github.com/goevexx/pterodactyl-api-node/issues/15)) ([436e7e0](https://github.com/goevexx/pterodactyl-api-node/commit/436e7e058ca48e8c0f2ab66fd3f97726b2d9fdb6))
+
+
+
 ## [1.0.1](https://github.com/goevexx/pterodactyl-api-node/compare/v1.0.0...v1.0.1) (2025-10-02)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "n8n-nodes-pterodactyl",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "n8n node for Pterodactyl Panel API integration",
 	"keywords": [
 		"n8n-community-node-package",


### PR DESCRIPTION
## Release v1.0.2

Version bump and CHANGELOG update for v1.0.2 release.

### Changes in this release:
- Remove setTimeout to pass n8n verification (#14, #15)

### After merge:
1. Create tag: `git tag v1.0.2 && git push origin v1.0.2`
2. This will trigger automated npm publish
3. Run scanner to verify: `npx @n8n/scan-community-package 'n8n-nodes-pterodactyl'`