### PR TITLE
fix: revert node version to 1 - credential validation is not a breaking change

### DIFF
--- a/nodes/Pterodactyl/Pterodactyl.node.ts
+++ b/nodes/Pterodactyl/Pterodactyl.node.ts
@@ -79,7 +79,7 @@ export class Pterodactyl implements INodeType {
 		name: 'pterodactyl',
 		icon: 'file:pterodactyl.svg',
 		group: ['transform'],
-		version: 2,
+		version: 1,
 		subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
 		description: 'Interact with Pterodactyl Panel API',
 		defaults: {


### PR DESCRIPTION
## Problem

Node version was incorrectly bumped to 2 in PR #24, but credential validation changes are NOT breaking changes:

- Existing workflows work exactly the same
- Just improved error messages
- No changes to inputs/outputs/behavior

## Solution

Revert node version from 2 back to 1.

## Node Version Guidelines

- **Version 1 → 2** = Breaking changes (changed inputs, outputs, or behavior that breaks existing workflows)
- **This PR** = Non-breaking improvements (better error messages)

## Verification

```typescript
version: 1,  // ✅ Correct - no breaking changes
```