### PR TITLE
fix: enable PAT_TOKEN for auto-tag to trigger publish workflow

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0 # Full history needed for tag creation
+          token: ${{ secrets.PAT_TOKEN }} # Use PAT to trigger publish workflow
 
       - name: Check if tag already exists
         if: steps.check.outputs.is_release == 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch: # Allow manual triggering for missed releases
 
 jobs:
   publish:


### PR DESCRIPTION
## Problem

The v1.3.0 tag was created successfully by auto-tag-release.yml, but the publish.yml workflow didn't trigger automatically.

## Root Cause

GitHub Actions security restriction: workflows triggered by  don't trigger downstream workflows. The auto-tag workflow was using the default  to push tags.

## Solution

1. **Use PAT_TOKEN in auto-tag workflow** - Allows tag push to trigger publish workflow
2. **Add workflow_dispatch to publish** - Enables manual triggering as fallback

## Changes

- : Use  for checkout
- : Add  trigger

## Testing

After this PR merges:
- Future release PRs will properly trigger publish workflow  
- Can manually trigger publish for v1.3.0

Fixes the issue where v1.3.0 tag exists but npm package wasn't published.