### PR TITLE
fix: correct operation value mismatches in Client API operations

### DIFF
--- a/nodes/PterodactylClient/PterodactylClient.node.ts
+++ b/nodes/PterodactylClient/PterodactylClient.node.ts
@@ -1187,7 +1187,7 @@ export class PterodactylClient implements INodeType {
 						responseData = await deleteBackup.call(this, i);
 					}
 				} else if (resource === 'account') {
-					if (operation === 'getAccount') {
+					if (operation === 'get') {
 						responseData = await getAccount.call(this, i);
 					} else if (operation === 'updateEmail') {
 						responseData = await updateEmail.call(this, i);
@@ -1223,31 +1223,31 @@ export class PterodactylClient implements INodeType {
 						responseData = await deleteTask.call(this, i);
 					}
 				} else if (resource === 'network') {
-					if (operation === 'listAllocations') {
+					if (operation === 'list') {
 						responseData = await listAllocations.call(this, i);
-					} else if (operation === 'assignAllocation') {
+					} else if (operation === 'assign') {
 						responseData = await assignAllocation.call(this, i);
 					} else if (operation === 'setPrimary') {
 						responseData = await setPrimary.call(this, i);
-					} else if (operation === 'deleteAllocation') {
+					} else if (operation === 'delete') {
 						responseData = await deleteAllocation.call(this, i);
 					} else if (operation === 'updateNotes') {
 						responseData = await updateNotes.call(this, i);
 					}
 				} else if (resource === 'subuser') {
-					if (operation === 'listSubusers') {
+					if (operation === 'list') {
 						responseData = await listSubusers.call(this, i);
 					} else if (operation === 'createSubuser') {
 						responseData = await createSubuser.call(this, i);
-					} else if (operation === 'getSubuser') {
+					} else if (operation === 'get') {
 						responseData = await getSubuser.call(this, i);
 					} else if (operation === 'updateSubuser') {
 						responseData = await updateSubuser.call(this, i);
-					} else if (operation === 'deleteSubuser') {
-					responseData = await deleteSubuser.call(this, i);
-				} else if (operation === 'getPermissions') {
-					responseData = await getPermissions.call(this, i);
-				}
+					} else if (operation === 'delete') {
+						responseData = await deleteSubuser.call(this, i);
+					} else if (operation === 'getPermissions') {
+						responseData = await getPermissions.call(this, i);
+					}
 				} else if (resource === 'startup') {
 					if (operation === 'getStartupVariables') {
 						responseData = await getStartupVariables.call(this, i);


### PR DESCRIPTION
## Summary
Fixes critical bug where 7 operations in the Client API were returning empty arrays due to mismatches between dropdown values and execute method operation checks.

## Problem
After PR #34 added the missing Operation dropdowns, several operations still didn't work because the dropdown values didn't match the values checked in the execute method.

For example:
- Account dropdown has `'get'` but execute checked for `'getAccount'`
- Network dropdown has `'list'` but execute checked for `'listAllocations'`
- Subuser dropdown has `'list'` but execute checked for `'listSubusers'`

## Changes
Fixed 7 operation value mismatches across 3 resources:

**Account Resource (1 fix):**
- ✅ `'get'` → matches `'get'` (was `'getAccount'`)

**Network Resource (3 fixes):**
- ✅ `'list'` → matches `'list'` (was `'listAllocations'`)
- ✅ `'assign'` → matches `'assign'` (was `'assignAllocation'`)
- ✅ `'delete'` → matches `'delete'` (was `'deleteAllocation'`)

**Subuser Resource (3 fixes):**
- ✅ `'list'` → matches `'list'` (was `'listSubusers'`)
- ✅ `'get'` → matches `'get'` (was `'getSubuser'`)
- ✅ `'delete'` → matches `'delete'` (was `'deleteSubuser'`)

## Testing
- ✅ Build: Successful
- ✅ Tests: 866 passing (54 test suites)
- ✅ All affected operations now functional

## Related
- Fixes issue reported after v1.3.1 release
- Complements PR #34 which added missing Operation dropdowns
- Part of critical fixes for v1.3.x series

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>